### PR TITLE
Remove assumepageview

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+
+2.1.0 / 2016-12-20
+==================
+
+  * Bump analytics.js-integration to ^3.2.0
+  * Remove .assumePageview() flag
+
 2.0.0 / 2016-06-21
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ var push = require('global-queue')('_dcq');
  */
 
 var Drip = module.exports = integration('Drip')
-  .assumesPageview()
   .global('_dc')
   .global('_dcq')
   .global('_dcqi')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-drip",
   "description": "The Drip analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-drip#readme",
   "dependencies": {
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.2.0",
     "global-queue": "^1.0.1",
     "isobject": "^2.1.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,6 @@ describe('Drip', function() {
 
   it('should have the right settings', function() {
     analytics.compare(Drip, integration('Drip')
-      .assumesPageview()
       .global('_dc')
       .global('_dcq')
       .global('_dcqi')


### PR DESCRIPTION
This removes the unneeded `.assumePageview()` flag since this integration doesn't even have a `.page()` call mapping. Also bumping ajs-integration version while at it.

This is causing issues for customers that have code inside `.ready()`

@tsholmes 