### PR TITLE
Spaces | EPD-2457 EPD-2543

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,10 @@
 
+2.1.1 / 2017-04-05
+==================
+
+  * replace spaces with underscores for track property names
+  * fix bug with value being sent with floating point
+
 2.1.0 / 2016-12-20
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@
 var integration = require('@segment/analytics.js-integration');
 var isObject = require('isobject');
 var push = require('global-queue')('_dcq');
+var each = require('@ndhoule/each');
 
 /**
  * Expose `Drip` integration.
@@ -52,8 +53,12 @@ Drip.prototype.loaded = function() {
  */
 
 Drip.prototype.track = function(track) {
-  var props = track.properties();
-  var cents = track.cents();
+  var props = {};
+  each(function(value, key) {
+    var formattedKey = key.replace(' ', '_');
+    props[formattedKey] = value;
+  }, track.properties());
+  var cents = Math.round(track.revenue() * 100);
   if (cents) props.value = cents;
   delete props.revenue;
   push('track', track.event(), props);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-drip",
   "description": "The Drip analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-drip#readme",
   "dependencies": {
+    "@ndhoule/each": "^2.0.1",
     "@segment/analytics.js-integration": "^3.2.0",
     "global-queue": "^1.0.1",
     "isobject": "^2.1.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,8 +90,13 @@ describe('Drip', function() {
       });
 
       it('should convert and alias revenue', function() {
-        analytics.track('event', { revenue: '$9.99' });
+        analytics.track('event', { revenue: '9.99' });
         analytics.called(window._dcq.push, ['track', 'event', { value: 999 }]);
+      });
+
+      it('should replace spaces with underscores in for property keys', function() {
+        analytics.track('event', { 'ahoy mate': 'howdy' });
+        analytics.called(window._dcq.push, ['track', 'event', { ahoy_mate: 'howdy' }]);
       });
     });
 


### PR DESCRIPTION
drip does not accept spaces in property names.

we should handle the stripping of spaces for track properties rather than asking our customers to do so. 

This should also fix same issue as https://github.com/segmentio/facade/pull/100 <- but we should still merge this separately as well

site-docs: https://github.com/segmentio/site-docs/pull/2207