### PR TITLE
Replaces spaces with underscores in identify keys.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,5 +72,10 @@ Drip.prototype.track = function(track) {
  */
 
 Drip.prototype.identify = function(identify) {
-  push('identify', identify.traits());
+  var props = {};
+  each(function(value, key) {
+    var formattedKey = key.replace(' ', '_');
+    props[formattedKey] = value;
+  }, track.identify());
+  push('identify', props);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,6 @@ Drip.prototype.identify = function(identify) {
   each(function(value, key) {
     var formattedKey = key.replace(' ', '_');
     props[formattedKey] = value;
-  }, track.identify());
+  }, identify.traits());
   push('identify', props);
 };


### PR DESCRIPTION
Spaces in keys in event properties are being replaced by underscores, but the same is not being done for the keys in identify method. This breaks Drip integration because Drip does not support spaces in the property keys.